### PR TITLE
[BugFix] add check for undefined values

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,13 @@ const core = require('@actions/core');
         for(const part of parts) {
             toReturn = toReturn[part];
         }
-        core.setOutput("value", toReturn);
+        if(toReturn === undefined) {
+            core.setFailed(`'${property}' does not exist in the provided JSON structure.`);
+        } else {
+            core.setOutput("value", toReturn);
+        }
 
     } catch (error) {
-   		core.setFailed(error.message);
+        core.setFailed(error.message);
     }
 })();


### PR DESCRIPTION
Ensures that the final `part` of `property` exists in the `json` object.

The following example illustrates that even if the final `part` of `property` does not exist in the `json` object: the code will still execute without throwing an error, and `toReturn` will be `undefined`.

```javascript
const json = {
  foo: {
    baz: true
  }
}

const parts = ["foo", "bar"]

let toReturn = json

for(const part of parts)
  {toReturn = toReturn[part]}

console.log(toReturn)
// undefined
```

By adding a check for `toReturn === undefined`, we can avoid returning an empty string.  

(*I noticed this issue when the action resulted in  
`./__Generated__/EXE/${{steps.get_exe_name.outputs.value}}.exe`  
being interpolated as  
`./__Generated__/EXE/.exe`  
due to an invalid final `property` `part`.*)